### PR TITLE
Add BuildRequires for openmpi4-gnu12-ohpc

### DIFF
--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -59,6 +59,7 @@ BuildRequires: chrpath sed grep which make
 BuildRequires: postgresql-devel binutils-devel
 BuildRequires: zlib-devel python3-devel
 BuildRequires: pdtoolkit-%{compiler_family}%{PROJ_DELIM}
+BuildRequires: %{mpi_family}-%{compiler_family}%{PROJ_DELIM}
 
 Requires: lmod%{PROJ_DELIM} >= 7.6.1
 Requires: pdtoolkit-%{compiler_family}%{PROJ_DELIM}


### PR DESCRIPTION
With this the build is successful: https://build.openeuler.org/package/live_build_log/home:huangtianhua:ohpc/tau-gnu12/standard_aarch64/aarch64