### PR TITLE
[msr-safe] Add BuildRequires for openEuler 22.03 

### DIFF
--- a/components/perf-tools/msr-safe/SPECS/msr-safe.spec
+++ b/components/perf-tools/msr-safe/SPECS/msr-safe.spec
@@ -42,6 +42,10 @@ BuildRequires: kernel-devel
 BuildRequires: kernel-abi-whitelists kernel-rpm-macros elfutils-libelf-devel
 %endif
 
+%if 0%{?openEuler}
+BuildRequires: kernel kernel-devel kernel-rpm-macros
+%endif
+
 %kernel_module_package default
 
 %description


### PR DESCRIPTION
Require `kernel`, `kernel-devel` and `kernel-rpm-macros` for builds on openEuler.