### PR TITLE
Preserve the SIMPLE_CI environment variable when executing the tests as user ohpc

### DIFF
--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -88,4 +88,4 @@ export SIMPLE_CI=1
 
 # Always running at least with '--enable-modules'. No need to check for
 # an empty TESTS array.
-su "${USER}" -l -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"
+su "${USER}" --whitelist-environment SIMPLE_CI -l -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -42,6 +42,10 @@ test_map = {
         'scotch',
         'zlib-devel'
     ],
+    '../components/parallel-libs/fftw/SPECS/fftw.spec': [
+        'fftw',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
 }
 
 

--- a/tests/libs/adios/tests/rm_execution
+++ b/tests/libs/adios/tests/rm_execution
@@ -14,9 +14,9 @@ testname="libs/ADIOS"
 
 NODES=2
 if [ -z "$SIMPLE_CI" ]; then
-    TASKS=2
-else
     TASKS=8
+else
+    TASKS=2
 fi
 
 @test "[$testname] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/fftw/tests/rm_execution
+++ b/tests/libs/fftw/tests/rm_execution
@@ -12,8 +12,13 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=8
 ARGS=8
+if [ -z "$SIMPLE_CI" ]; then
+    TASKS=8
+else
+    TASKS=2
+fi
+
 
 TIMEOUT="00:05:00"
 


### PR DESCRIPTION
Add mapping for FFTW test.
Fix the value of TASKS depending on whether or not SIMPLE_CI is exported.

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>