### PR TITLE
Use Ana06/get-changed-files instead of jitterbit/get-changed-files

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         fetch-depth: 0
     - id: files
-      uses: jitterbit/get-changed-files@v1
+      uses: Ana06/get-changed-files@v2.2.0
     - name: Validate Changes
       run: |
         tests/ci/check_spec.py ${{ steps.files.outputs.added_modified }}
@@ -66,7 +66,7 @@ jobs:
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
     - id: files
-      uses: jitterbit/get-changed-files@v1
+      uses: Ana06/get-changed-files@v2.2.0
     - name: Validate Build
       run: |
         . /etc/profile.d/lmod.sh
@@ -95,7 +95,7 @@ jobs:
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
     - id: files
-      uses: jitterbit/get-changed-files@v1
+      uses: Ana06/get-changed-files@v2.2.0
     - uses: actions/download-artifact@v3
       with:
         name: rhel-rpms
@@ -128,7 +128,7 @@ jobs:
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
     - id: files
-      uses: jitterbit/get-changed-files@v1
+      uses: Ana06/get-changed-files@v2.2.0
     - name: Validate Build
       run: |
         . /etc/profile.d/lmod.sh
@@ -146,7 +146,7 @@ jobs:
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
     - id: files
-      uses: jitterbit/get-changed-files@v1
+      uses: Ana06/get-changed-files@v2.2.0
     - name: Validate Build
       run: |
         . /etc/profile.d/lmod.sh


### PR DESCRIPTION
jitterbit/get-changed-files@v1 often fails with errors like:

```
Base commit: c06f2fe4456f933cafcde33a8a764a2d7bf47635 
Head commit: 55342d52e87b98e9d2d06d2b1c54152d7d4acc02 
Error: The head commit for this pull_request event is not ahead of the base commit. Please submit an issue on this action's GitHub repo. All: components/perf-tools/msr-safe/SPECS/msr-safe.spec Added:
Modified: components/perf-tools/msr-safe/SPECS/msr-safe.spec Removed:
Renamed:
Added or modified: components/perf-tools/msr-safe/SPECS/msr-safe.spec
```
This issue is known since a long time but it seems the action is not maintained anymore:
https://github.com/jitterbit/get-changed-files/issues?q=The+head+commit+for+this+pull_request+event+is+not+ahead

https://github.com/Ana06/get-changed-files is a maintained fork that claims to have fixed this issue: https://github.com/jitterbit/get-changed-files/issues/11#issuecomment-854657301

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>